### PR TITLE
Remove ul from links.twig

### DIFF
--- a/migrations/2015_05_21_061832_anomaly.module.navigation__1_0_0__create_navigation_fields.php
+++ b/migrations/2015_05_21_061832_anomaly.module.navigation__1_0_0__create_navigation_fields.php
@@ -26,6 +26,7 @@ class AnomalyModuleNavigation_1_0_0_CreateNavigationFields extends Migration
                 'slugify' => 'name'
             ]
         ],
+        'classes'     => 'anomaly.field_type.text',
         'group'       => [
             'type'   => 'anomaly.field_type.relationship',
             'config' => [

--- a/migrations/2015_05_21_064952_anomaly.module.navigation__1_0_0__create_links_stream.php
+++ b/migrations/2015_05_21_064952_anomaly.module.navigation__1_0_0__create_links_stream.php
@@ -40,6 +40,7 @@ class AnomalyModuleNavigation_1_0_0_CreateLinksStream extends Migration
         'target' => [
             'required' => true
         ],
+        'classes',
         'parent'
     ];
 

--- a/resources/lang/en/field.php
+++ b/resources/lang/en/field.php
@@ -16,5 +16,9 @@ return [
             'self'  => 'Load in the current window.',
             'blank' => 'Load in a new window.'
         ]
+    ],
+    'classes'     => [
+        'name'        => 'Classes',
+        'placeholder' => 'Any additional classes (separated by spaces)'
     ]
 ];

--- a/resources/views/links.twig
+++ b/resources/views/links.twig
@@ -1,5 +1,3 @@
 {% import "anomaly.module.navigation::macro" as macro %}
 
-<ul {{ html_attributes(options.attributes) }}>
-    {{ macro.links(links.root(), links, group, options) }}
-</ul>
+{{ macro.links(links.root(), links, group, options) }}

--- a/resources/views/macro.twig
+++ b/resources/views/macro.twig
@@ -1,6 +1,6 @@
 {% macro links(links, collection, group, options) %}
     {% for link in links %}
-        <li class="{{ link.current ? 'current' }} {{ link.active ? 'active' }}">
+        <li class="{{ link.current ? 'current' }} {{ link.active ? 'active' }} {{ link.classes }}">
             <a href="{{ link.url }}" target="{{ link.target }}">
                 {{ link.title }}
             </a>


### PR DESCRIPTION
I like this way better since it gives the designer more control over appending static elements to the beginning and end of the menu without having to do any hacks. You also have control over the ul element without having to pass in {'attributes': 'style="background-color: green;"'} to the navigation_render method.

If you like it better the other way then just nuke this PR.
