### PR TITLE
Fixing link edit URLs in Link Tree

### DIFF
--- a/src/Link/Tree/LinkTreeBuilder.php
+++ b/src/Link/Tree/LinkTreeBuilder.php
@@ -41,15 +41,6 @@ class LinkTreeBuilder extends TreeBuilder
     ];
 
     /**
-     * The tree options.
-     *
-     * @var array
-     */
-    protected $segments = [
-        '<a href="/admin/navigation/links/{request.route.parameters.group}/edit/{entry.id}">{entry.title}</a>'
-    ];
-
-    /**
      * Fired when the builder is ready to build.
      *
      * @throws \Exception

--- a/src/Link/Tree/LinkTreeSegments.php
+++ b/src/Link/Tree/LinkTreeSegments.php
@@ -1,0 +1,27 @@
+<?php namespace Anomaly\NavigationModule\Link\Tree;
+
+/**
+ * Class LinkTreeSegments
+ *
+ * @link          http://anomaly.is/streams-platform
+ * @author        AnomalyLabs, Inc. <hello@anomaly.is>
+ * @author        Ryan Thompson <ryan@anomaly.is>
+ * @package       Anomaly\NavigationModule\Link\Tree
+ */
+class LinkTreeSegments
+{
+
+    /**
+     * Handle the tree segments.
+     *
+     * @param LinkTreeBuilder $builder
+     */
+    public function handle(LinkTreeBuilder $builder)
+    {
+        $builder->setSegments(
+            [
+                '<a href="' . url("/admin/navigation/links/{request.route.parameters.group}/edit/{entry.id}") . '">{entry.title}</a>'
+            ]
+        );
+    }
+}


### PR DESCRIPTION
URLs of the edit links in the Link Tree were pointing to wrong URLs, i.e. `localhost/admin/navigation/links/{request.route.parameters.group}/edit/{entry.id}` instead of `localhost/appname/admin/navigation/links/{request.route.parameters.group}/edit/{entry.id}`. Deleted `$segment` in `LinkTreeBuilder` and created `LinkTreeSegments` instead, so URL could be wrapped in `url()` function.
