### PR TITLE
added multiple current support

### DIFF
--- a/src/Link/Command/SetCurrentLink.php
+++ b/src/Link/Command/SetCurrentLink.php
@@ -67,16 +67,17 @@ class SetCurrentLink
             } elseif ($link->path() == $path) {
                 $current = $link;
             }
-        }
 
-        /**
-         * If we have an current link determined
-         * then mark it as such.
-         *
-         * @var LinkInterface $current
-         */
-        if ($current) {
-            $current->setCurrent(true);
+            /**
+             * If we have an current link determined
+             * then mark it as such.
+             *
+             * @var LinkInterface $current
+             */
+            if ($current) {
+                $current->setCurrent(true);
+                $current = null;
+            }
         }
     }
 }


### PR DESCRIPTION
added multiple `current` support / fixed bug.

Multiple links can be active in case of hashtags:

- /about-us
- /about-us#team
- /about-us#location

In the following list only `/about-us#location` gets a state of `current`
