### PR TITLE
Fix Home-Path

### DIFF
--- a/src/Link/LinkModel.php
+++ b/src/Link/LinkModel.php
@@ -67,7 +67,7 @@ class LinkModel extends NavigationLinksEntryModel implements LinkInterface
      */
     public function path()
     {
-        $pattern = '/^\/(' . implode('|', array_keys(config('streams::locales.supported'))) . ')\//';
+        $pattern = '/^\/(' . implode('|', array_keys(config('streams::locales.supported'))) . ')(\/|$)/';
 
         return preg_replace($pattern, '/', array_get(parse_url($this->getUrl()), 'path'));
     }


### PR DESCRIPTION
previous regex doesn't match language hint in home-path (no '/' after the language hint)