### PR TITLE
Fix current with locale segment

### DIFF
--- a/src/Link/Command/SetCurrentLink.php
+++ b/src/Link/Command/SetCurrentLink.php
@@ -54,7 +54,10 @@ class SetCurrentLink
         $staticPrefix = $compiled->getStaticPrefix();
 
         $host    = $request->getHost();
-        $exact   = $request->fullUrl();
+        // Use the url generator to get the exact path as this
+        // will include the locale path segment if present which is
+        // removed from the request
+        $exact   = url()->current();
         $partial = $request->getUriForPath($staticPrefix);
 
         $path = array_get(parse_url($partial), 'path');


### PR DESCRIPTION
Use the URL generator to compare paths when deciding if a menu item is the current item as this will include the locale segment. The local segment is removed from the request url by the kernel but the url generator is aware of the missing segment and replaces it when generating urls.